### PR TITLE
get bridge fee for usdc and usdt erc20

### DIFF
--- a/wallet/contracts.js
+++ b/wallet/contracts.js
@@ -1031,7 +1031,7 @@ module.exports = function({ store, web3t}) {
 											maxPerTx: maxPerTx,
 											remainingDailyLimit: remainingDailyLimit
 										});
-										if (token !== 'busd') {
+										if (token !== 'busd' && token !== 'usdc' && token !== 'usdt_erc20') {
                       return cb(null);
                     }
                     var wallets = store.current.account.wallets;


### PR DESCRIPTION
# [Task name](https://velasnetwork.atlassian.net/browse/VLWA-975)

## Description

Add ability to fetch foreign bridge fee for usdc and usdt tokens in swap.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
. 
 
- Switch to Testnet network
- Press swap for USDT / USDC on Ethrereum chain
- Bridge fee field appeared on the screen.

### Platforms tested on

- [x] Android
- [x] IOS

### Image(s) showcasing change, if possible
