### PR TITLE
bugfix: If getTransactions method returns error, result becomes an em…

### DIFF
--- a/wallet/transactions.js
+++ b/wallet/transactions.js
@@ -177,7 +177,9 @@
       function (err, data) {
         var ids, dummy;
         if (err != null) {
-          return cb(err);
+          console.error(`getTransactions error, ${coin.token} token`, err);
+          /* Clear previous txs result in case error. */
+          data = []
         }
         ids = map(function (it) {
           return it.tx.toUpperCase();


### PR DESCRIPTION
# [Same tx history for BSC network tokens after changing network](https://velasnetwork.atlassian.net/browse980)

## Description

Tx history must be different on diff networks.

Fixes # (issue)

## How Has This Been Tested?

- [ ] Check on mainnet txs history for any token of BSC network
- [ ] change network
- [ ] Check txs history again (It must be different)

### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible
