### PR TITLE
Fix/add tokens list show wrong wallets to add after switching network

### DIFF
--- a/pages/AddWallets.js
+++ b/pages/AddWallets.js
@@ -117,7 +117,7 @@ export default ({ store, web3t }) => {
   };
 
   const currentNetwork = store.current.network;
-	coinItems = coinItems.filter((it)=> {
+	const $coinItems = coinItems.filter((it)=> {
 		return !it[currentNetwork].disabled
 	});
   const refreshToken = async bool => {};
@@ -129,10 +129,10 @@ export default ({ store, web3t }) => {
 		})(
 			filter(function(arg$){
 				var network = arg$[currentNetwork];
-				return network.disabled !== true
+				return !network.disabled
 			})(wallets));
 	}
-	const walletsGroups = getWalletsGroups({wallets: coinItems});
+	const walletsGroups = getWalletsGroups({wallets: $coinItems});
 	const groups = keys(walletsGroups);
 	groups.splice(groups.indexOf('Velas'),1);
 	groups.unshift('Velas');

--- a/wallet/refresh-account.js
+++ b/wallet/refresh-account.js
@@ -94,8 +94,9 @@
           store.rates = bgStore.rates;
           store.current.account = bgStore.current.account;
           store.current.filter.filterTxsTypes = ['IN', 'OUT'];
+          const filterToken = wallet.coin != null ? wallet.coin.token : '';
           store.current.filter = {
-            token: wallet.coin.token,
+            token: filterToken,
           };
           store.current.balanceUsd = bgStore.current.balanceUsd;
           return refreshTxs(web3, store, function () {


### PR DESCRIPTION
# [Wrong 'add tokens list' is shown after switching network from testnet to mainnet](https://velasnetwork.atlassian.net/browse/VLWA-1034)

## Description

AR: token list from testnet is shown
ER: token list from mainnet is shown

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Switch to testnet
- [ ] Go to Wallets
- [ ] Add any token
- [ ] Switch to Mainnet
- [ ] Go to Wallets
- [ ] Tap Add tokens button top right

### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible
