### PR TITLE
Increase staking page loading performance vlwa-1137

### DIFF
--- a/components/ButtonBlock.js
+++ b/components/ButtonBlock.js
@@ -6,7 +6,6 @@ import Images from '../Images';
 
 export default (props) => {
   const netInfo = useNetInfo();
-  console.info('netInfo', netInfo);
   const validatorNet =
     !netInfo.details ||
     netInfo.isConnected ||

--- a/staking/validator-model-backed.js
+++ b/staking/validator-model-backed.js
@@ -133,9 +133,8 @@ class ValidatorModelBacked {
       if (acc.state !== 'activating' && acc.state !== 'active') {
         continue;
       }
-      if (acc.parsedAccoount.account.data.parsed.info.meta.lockup) {
-        const unixTimestamp =
-          acc.parsedAccoount.account.data.parsed.info.meta.lockup.unixTimestamp;
+      const unixTimestamp = acc.unixTimestamp;
+      if (unixTimestamp) {
         const now = Date.now() / 1000;
         if (unixTimestamp > now) continue;
       }
@@ -229,9 +228,8 @@ class ValidatorModelBacked {
       if (!acc.inactiveStake) {
         return null;
       }
-      if (acc.parsedAccoount.account.data.parsed.info.meta.lockup) {
-        const unixTimestamp =
-          acc.parsedAccoount.account.data.parsed.info.meta.lockup.unixTimestamp;
+      const unixTimestamp = acc.unixTimestamp;
+      if (unixTimestamp) {
         const now = Date.now() / 1000;
         if (unixTimestamp > now) continue;
       }

--- a/staking/validator-model-backed.js
+++ b/staking/validator-model-backed.js
@@ -205,9 +205,8 @@ class ValidatorModelBacked {
       if (!acc.activeStake) {
         return null;
       }
-      if (acc.parsedAccoount.account.data.parsed.info.meta.lockup) {
-        const unixTimestamp =
-          acc.parsedAccoount.account.data.parsed.info.meta.lockup.unixTimestamp;
+      const unixTimestamp = acc.unixTimestamp;
+      if (unixTimestamp) {
         const now = Date.now() / 1000;
         if (unixTimestamp > now) continue;
       }


### PR DESCRIPTION
# [Set new stake accounts api endpoint in order to increase loading staking page performance](https://velasnetwork.atlassian.net/browse/VLWA-1137)

## Description

**getParsedAccounts** query was too slow. In order to increase loading speed of validators page, **new api** from backend is being used.

Fixes # (issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Enter Validators tab
- [ ] Average loading page performance is about 10-20 seconds
 
### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible


<!-- Replace -->
[vlwa-1137](https://velasnetwork.atlassian.net/browse/vlwa-1137) – [Mobile] Set new stake accounts api endpoint in order to increase loading staking page performance
<!-- Replace -->
