### PR TITLE
fix [VLWA-1156] - usdt legacy send

### DIFF
--- a/web3t/providers/usdt_erc20_legacy.js
+++ b/web3t/providers/usdt_erc20_legacy.js
@@ -479,6 +479,7 @@ import commonProvider from './common/provider';
                 }
                 return commonProvider.web3EthGetBalance(
                   account.address,
+                  network,
                   function (err, balance) {
                     var balanceEth;
                     if (err != null) {


### PR DESCRIPTION

## Description

- added missing arg for `web3EthGetBalance` in `createTransaction` in `usdt_erc20_legacy`