### PR TITLE
bugfix: set swap flag to false in case we scan QR from wallet page VLWA-1182

### DIFF
--- a/pages/Wallet.js
+++ b/pages/Wallet.js
@@ -211,6 +211,7 @@ export default ({ store, web3t }) => {
 
   const scanQRSend = () => {
     if (wallet.balance == '..') return;
+    if (store.current.page === 'wallet') store.current.send.isSwap = false;
     store.current.returnPage = 'wallet';
     return (store.current.page = 'Scanner');
     //store.current.send.to = "VJWAMYt4A1o3pwSJLzvJqHBL1wxvLBSpsQ";

--- a/pages/Wallet.js
+++ b/pages/Wallet.js
@@ -211,7 +211,10 @@ export default ({ store, web3t }) => {
 
   const scanQRSend = () => {
     if (wallet.balance == '..') return;
-    if (store.current.page === 'wallet') store.current.send.isSwap = false;
+    if (store.current.page === 'wallet') {
+      store.current.send.isSwap = false;
+      store.current.send.data = '0x';
+    }
     store.current.returnPage = 'wallet';
     return (store.current.page = 'Scanner');
     //store.current.send.to = "VJWAMYt4A1o3pwSJLzvJqHBL1wxvLBSpsQ";


### PR DESCRIPTION
# [Task name](https://velasnetwork.atlassian.net/browse/VLWA-NUMBER_HERE)

There is a bug where users enter swap page then goes back press scan QR and swap screen is opened.

**Instructions to reproduce**
- [ ] Enter swap screen
- [ ] Press back button
- [ ] Press Scan QR
- [ ] Swap page is opened instead Send

### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible


<!-- Replace -->
[VLWA-1182](https://velasnetwork.atlassian.net/browse/VLWA-1182) – Scan QR bugfix.
<!-- Replace -->
