### PR TITLE
feature/VLWA-988: Hide token VELAS EVM LEGACY from the token list by default, because it isn't used #131

### DIFF
--- a/setupWallet.js
+++ b/setupWallet.js
@@ -11,12 +11,11 @@ import getLang from './wallet/get-lang.js';
 import initStaking from './initStaking.js';
 import ethLegacy from './registry/eth-legacy-coin';
 import usdtErc20Legacy from './registry/usdt_erc20_legacy-coin';
-import vlxEvmLegacy from './registry/vlx-evm-legacy-coin';
 import { filter, map } from 'prelude-ls';
 import walletsFuncs from './wallet/wallets-funcs';
 
 module.exports = (store, web3t) => {
-  const legacyTokens = [ethLegacy, usdtErc20Legacy, vlxEvmLegacy];
+  const legacyTokens = [ethLegacy, usdtErc20Legacy];
 
   function preinstallCoins([coin, ...coins], cb) {
     if (!coin) {


### PR DESCRIPTION
# [VLWA-988](https://velasnetwork.atlassian.net/browse/VLWA-988)

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Step 1
- [ ] Step 2

### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible


<!-- Replace -->
[VLWA-988](https://velasnetwork.atlassian.net/browse/VLWA-988) – Hide token VELAS EVM LEGACY from the token list by default, because it isn't used
<!-- Replace -->
