### PR TITLE
VLWA-1413 Replace unsupported git protocol from dependencies lock

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,17 +1,3 @@
 ## Description
 
 Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-
-## How Has This Been Tested?
-
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
-
-- [ ] Step 1
-- [ ] Step 2
-
-### Platforms tested on
-
-- [ ] Android
-- [ ] IOS
-
-### Image(s) showcasing change, if possible

--- a/yarn.lock
+++ b/yarn.lock
@@ -14985,7 +14985,7 @@ react-native-simple-markdown@^1.1.0:
   integrity sha1-TUYvjO0mOTxSMEZ0IMYaUMxqgJU=
   dependencies:
     lodash "^4.15.0"
-    simple-markdown "git://github.com/CharlesMangwa/simple-markdown.git"
+    simple-markdown "https://github.com/CharlesMangwa/simple-markdown.git"
 
 react-native-sliding-up-down-panels@1.0.0:
   version "1.0.0"
@@ -16323,9 +16323,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
-"simple-markdown@git://github.com/CharlesMangwa/simple-markdown.git":
+"simple-markdown@https://github.com/CharlesMangwa/simple-markdown.git":
   version "0.1.1"
-  resolved "git://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1"
+  resolved "https://github.com/CharlesMangwa/simple-markdown.git#33d963c760b8196bee01b1a5ba9974bc7f669af1"
 
 simple-plist@^1.0.0, simple-plist@^1.1.0:
   version "1.1.1"


### PR DESCRIPTION
- according to https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Step 1
- [ ] Step 2

### Platforms tested on

- [ ] Android
- [ ] IOS

### Image(s) showcasing change, if possible


<!-- Replace -->
[VLWA-1413](https://velasnetwork.atlassian.net/browse/VLWA-1413) – Replace unsupported git protocol from dependencies lock
<!-- Replace -->
