### PR TITLE
VLWA-1402 long waiting time for validators list opening

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "pretty": "prettier --write .",
     "install": "pwd && cp scripts/pre-commit .git/hooks/ && chmod u+x .git/hooks/pre-commit && chmod u+x scripts/bump-version.sh",
     "clean:android": "rm -rf node_modules/ && yarn && cd android && ./gradlew clean",
-    "reset": "watchman watch-del-all && rm -rf node_modules && yarn && yarn pod && yarn start --reset-cache",
+    "clear:cache": "lsof -ti:8081 | xargs kill && yarn start --reset-cache",
+    "reset": "watchman watch-del-all && rm -rf node_modules && yarn && yarn pod && yarn clear:cache",
     "pod": "cd ./ios && pod install && cd ..",
     "prepare": "husky install"
   },

--- a/staking/validator-model-backed.js
+++ b/staking/validator-model-backed.js
@@ -1,9 +1,6 @@
-import { decorate, observable, action, when } from 'mobx';
+import { decorate, observable } from 'mobx';
 import BN from 'bn.js';
 import { StakingAccountModel } from './staking-account-model.js';
-import { cachedCallWithRetries } from './utils';
-import { rewardsStore } from './rewards-store';
-const solanaWeb3 = require('./index.cjs.js');
 
 class ValidatorModelBacked {
   network = null;


### PR DESCRIPTION
[fix] VLWA-1463 rewards from node only if no be
- Load rewards for apr from node only if BE doesn't work https://velasnetwork.atlassian.net/browse/VLWA-1463

- use `rewardsStore.setConnection` only for node rpc because we got `apr` from backend

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
